### PR TITLE
Don't die on valid emails, but do exit with code 1

### DIFF
--- a/processJETIemails.rb
+++ b/processJETIemails.rb
@@ -113,6 +113,7 @@ def unpack_b_or_q(s_text)
 end
 
 configfile = ArgsParserValidator.parse(ARGV)
+every_email_has_been_posted = true
 
 if (configfile.length > 0)
     config = YAML.load(File.read(configfile)) 
@@ -139,9 +140,12 @@ if (configfile.length > 0)
             textbody = messagefinder.get_text_body(msg)
             jiraservice.post_internal_comment(issuekey,"From: #{thatfromfield}\nDate:#{msg.attr["ENVELOPE"].date}\n\n#{textbody}")
             messagefinder.move_message(msg,config["destmailbox"])
-        rescue RuntimeError => e
+        rescue StandardError => e
+            every_email_has_been_posted = false
             puts "Couldn't post comment to JIRA ticket! Issue key: #{issuekey}"
             puts e.message
         end
     end
 end
+
+exit 1 unless every_email_has_been_posted


### PR DESCRIPTION
Previously, it would exit as soon as it found any bad email, and it
wouldn't send anything else, because it had errorred out. Catching
StandardError instead of RuntimeError fixed that, but then we weren't
getting emails when there were problems because it was exiting 0 after
logging the failures.

So I added the ugly lines tracking whether we've failed to send any
emails because I wasn't willing to try and refactor this.