### PR TITLE
AEIM-1297: don't die on non-utf-8 messages

### DIFF
--- a/processJETIemails.rb
+++ b/processJETIemails.rb
@@ -50,7 +50,7 @@ class IMAPService
     def get_text_body(msg)
         mm = Mail.read_from_string msg.attr["RFC822"]
         if (mm.text_part)
-           mm.text_part.body.to_s
+           mm.text_part.decoded
         elsif (mm.html_part) 
            Nokogiri::HTML(mm.html_part.decoded.to_s).text
         else


### PR DESCRIPTION
In this case mm.text_part.charset was Windows-1252.
mm.text_part.body.to_s.encoding was ASCII-8BIT, and attempting to force
encoding UTF-8 caused an error. mm.text_part.decoded appears to honor
mm.text_part.charset and convert the text to UTF-8.